### PR TITLE
Enable github editing links

### DIFF
--- a/sphinx-bootstrap/layout.html
+++ b/sphinx-bootstrap/layout.html
@@ -19,10 +19,11 @@
             {% block sidebarrel %}
               {% include "relations.html" %}
             {% endblock %}
-            {% block sidebarsourcelink %}
+          </ul>
+          <ul class="nav pull-right">
+            {% block sidebarsourcelink2 %}
               {% include "sourcelink.html" %}
             {% endblock %}
-          </ul>
           {% block sidebarsearch %}
             {% include "searchbox.html" %}
           {% endblock %}

--- a/sphinx-bootstrap/sourcelink.html
+++ b/sphinx-bootstrap/sourcelink.html
@@ -1,4 +1,7 @@
 {%- if show_source and has_source and sourcename %}
   <li><a href="{{ pathto('_sources/' + sourcename, true)|e }}"
-         rel="nofollow">{{ _('Source') }}</a></li>
+	  rel="nofollow"><i class="icon-file"></i> {{ _('Source') }}</a></li>
+{%- endif %}
+{%- if READTHEDOCS %}
+  <li><a href="https://github.com/{{ github_user }}/{{ github_repo }}/edit/{{ github_version }}{{ conf_py_path }}{{ pagename }}.rst"><i class="icon-pencil"></i> {{ _('Edit') }}</a></li>
 {%- endif %}


### PR DESCRIPTION
Julen, would you mind reviewing this as I'm not an expert in CSS and this theme.

My main aim was to neaten up the RTD links that allow Github editing.  The main problem is by default they don't work in our theme. So I've made some adjustments to allow us to enable the editing.

What I've done:
- Use FontAwesome icons - only on source/editing links
- Enabled Edit link if on RTD
- Pull Source/Edit links right but keep left of search - so moving them away from the navigation bar to prevent cluttering.
